### PR TITLE
Update version of dependency torrent-stream.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "filesize": "^3.0.1",
     "underscore": "^1.7.0",
     "parse-torrent": "^3.0.1",
-    "torrent-stream": "^0.16.2"
+    "torrent-stream": "^1.0.0"
   }
 }

--- a/torrent-xiv.js
+++ b/torrent-xiv.js
@@ -1,4 +1,3 @@
-
 var _ =             require('underscore');
 var os =            require('os');
 var path =          require('path');


### PR DESCRIPTION
Fixes a bug where torrents don't start downloading after a previous shutdown of the client. The caret specification of the version number prevents npm from installing a newer version (limits to 0.16.X releases).
